### PR TITLE
store shared files in share/{PROJECT_NAME} rather than share/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,11 @@ install(TARGETS ${library_name}
 )
 
 install(DIRECTORY example
-  DESTINATION share
+  DESTINATION share/${PROJECT_NAME}
 )
 
 install(FILES costmap_plugins.xml
-  DESTINATION share
+  DESTINATION share/${PROJECT_NAME}
 )
 
 ament_export_include_directories(include)


### PR DESCRIPTION
fixes: https://github.com/ros-planning/navigation2/issues/1480