### PR TITLE
dont deadlock

### DIFF
--- a/plugins/nonpersistent_voxel_layer.cpp
+++ b/plugins/nonpersistent_voxel_layer.cpp
@@ -118,15 +118,13 @@ void NonPersistentVoxelLayer::matchSize()
 
 void NonPersistentVoxelLayer::reset()
 {
-  deactivate();
+  ObstacleLayer::reset();
   resetMaps();
-  voxel_grid_.reset();
-  activate();
 }
 
 void NonPersistentVoxelLayer::resetMaps()
 {
-  Costmap2D::resetMaps();
+  ObstacleLayer::resetMaps();
   voxel_grid_.reset();
 }
 


### PR DESCRIPTION
apply same fix as "fix for #1363" on nav2_costmap_2d

on humble callbacks invoked by `testTransformableRequets` takes a lock on two mutexs.
The same two are taken in the opposite order when `reset` here calls `activate`