### PR TITLE
Use combination_method_from_int for type conversion

### DIFF
--- a/plugins/nonpersistent_voxel_layer.cpp
+++ b/plugins/nonpersistent_voxel_layer.cpp
@@ -63,8 +63,8 @@ void NonPersistentVoxelLayer::onInitialize()
   enabled_ = node->get_parameter(name_ + ".enabled").as_bool();
   max_obstacle_height_ = node->get_parameter(
     name_ + ".max_obstacle_height").as_double();
-  combination_method_ = node->get_parameter(
-    name_ + ".combination_method").as_int();
+  combination_method_ = combination_method_from_int(node->get_parameter(
+    name_ + ".combination_method").as_int());
 
   size_z_ = node->declare_parameter(name_ + ".z_voxels", 16);
   origin_z_ = node->declare_parameter(name_ + ".origin_z", 16.0);


### PR DESCRIPTION
to fix ggc error with Ubuntu 24.04 for ROS 2 Jazzy:

```
/opt/overlay_ws/src/nonpersistent_voxel_layer/plugins/nonpersistent_voxel_layer.cpp: In member function 'virtual void nav2_costmap_2d::NonPersistentVoxelLayer::onInitialize()':
/opt/overlay_ws/src/nonpersistent_voxel_layer/plugins/nonpersistent_voxel_layer.cpp:67:42: error: cannot convert 'int64_t' {aka 'long int'} to 'nav2_costmap_2d::CombinationMethod' in assignment
   66 |   combination_method_ = node->get_parameter(
      |                         ~~~~~~~~~~~~~~~~~~~~
   67 |     name_ + ".combination_method").as_int();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
      |                                          |
      |                                          int64_t {aka long int}
gmake[2]: *** [CMakeFiles/nonpersistent_voxel_layer_core.dir/build.make:76: CMakeFiles/nonpersistent_voxel_layer_core.dir/plugins/nonpersistent_voxel_layer.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/nonpersistent_voxel_layer_core.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```