### PR TITLE
Sync changes with nav2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,47 +10,28 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(geometry_msgs REQUIRED)
 find_package(laser_geometry REQUIRED)
-find_package(map_msgs REQUIRED)
-find_package(message_filters REQUIRED)
-find_package(nav_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(visualization_msgs REQUIRED)
 find_package(nav2_voxel_grid REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
-find_package(Eigen3 REQUIRED)
+find_package(nav2_ros_common REQUIRED)
 
 set(dependencies
-	geometry_msgs
 	laser_geometry
-	map_msgs
-	message_filters
-	nav_msgs
 	pluginlib
 	sensor_msgs
-  nav2_msgs
+  	nav2_msgs
 	rclcpp
-	std_msgs
-	tf2
-	tf2_ros
-	visualization_msgs
 	nav2_voxel_grid
 	nav2_costmap_2d)
 
 set(library_name nonpersistent_voxel_layer_core)
 
-add_definitions(${EIGEN3_DEFINITIONS})
-
 include_directories(
     include
-    ${EIGEN3_INCLUDE_DIRS}
 )
 
 add_library(${library_name} SHARED
@@ -60,11 +41,11 @@ add_library(${library_name} SHARED
 target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 target_link_libraries(${library_name}
-  ${EIGEN3_LIBRARIES}
-)
-
-ament_target_dependencies(${library_name}
-  ${dependencies}
+  ${sensor_msgs_TARGETS}
+  laser_geometry::laser_geometry
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_voxel_grid::voxel_grid
+  nav2_ros_common::nav2_ros_common
 )
 
 if(BUILD_TESTING)

--- a/include/nonpersistent_voxel_layer/nonpersistent_voxel_layer.hpp
+++ b/include/nonpersistent_voxel_layer/nonpersistent_voxel_layer.hpp
@@ -45,13 +45,10 @@
 #include "nav2_costmap_2d/layered_costmap.hpp"
 #include "nav2_costmap_2d/observation_buffer.hpp"
 #include "nav2_voxel_grid/voxel_grid.hpp"
-#include "nav_msgs/msg/occupancy_grid.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "laser_geometry/laser_geometry.hpp"
 #include "sensor_msgs/msg/point_cloud.hpp"
 #include "sensor_msgs/msg/point_cloud2.h"
-#include "tf2_ros/message_filter.h"
-#include "message_filters/subscriber.h"
 #include "nav2_costmap_2d/obstacle_layer.hpp"
 #include "nav2_msgs/msg/voxel_grid.hpp"
 
@@ -91,7 +88,7 @@ protected:
 
 private:
   bool publish_voxel_;
-  rclcpp::Publisher<nav2_msgs::msg::VoxelGrid>::SharedPtr voxel_pub_;
+  nav2::Publisher<nav2_msgs::msg::VoxelGrid>::SharedPtr voxel_pub_;
   nav2_voxel_grid::VoxelGrid voxel_grid_;
   double z_resolution_, origin_z_;
   unsigned int unknown_threshold_, mark_threshold_, size_z_;

--- a/package.xml
+++ b/package.xml
@@ -15,18 +15,11 @@
 
     <buildtool_depend>ament_cmake</buildtool_depend>
 
-    <depend>geometry_msgs</depend>
     <depend>laser_geometry</depend>
-    <depend>map_msgs</depend>
-    <depend>nav_msgs</depend>
     <depend>nav2_msgs</depend>
     <depend>pluginlib</depend>
     <depend>rclcpp</depend>
     <depend>sensor_msgs</depend>
-    <depend>std_msgs</depend>
-    <depend>tf2_ros</depend>
-    <depend>tf2</depend>
-    <depend>visualization_msgs</depend>
     <depend>nav2_voxel_grid</depend>
     <depend>nav2_costmap_2d</depend>
 

--- a/plugins/nonpersistent_voxel_layer.cpp
+++ b/plugins/nonpersistent_voxel_layer.cpp
@@ -80,7 +80,7 @@ void NonPersistentVoxelLayer::onInitialize()
   if (publish_voxel_) {
     voxel_pub_ =
       node->create_publisher<nav2_msgs::msg::VoxelGrid>(
-      "voxel_grid", rclcpp::QoS(1));
+      "voxel_grid", nav2::qos::StandardTopicQoS(1));
   }
 
   matchSize();


### PR DESCRIPTION
This pr sync changes with nav2, remove the packages that are unnecessary, and update from ament_target_dependencies to target_link_libraries