### PR TITLE
Fix missing nav2_costmap_2d symbols at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${library_name}
   ${sensor_msgs_TARGETS}
   laser_geometry::laser_geometry
   nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_costmap_2d::layers
   nav2_voxel_grid::voxel_grid
   nav2_ros_common::nav2_ros_common
 )


### PR DESCRIPTION
Explicitly link `nav2_costmap_2d::layers` to fix undefined symbol on runtime:

`
Error string: Could not load library dlopen error: /opt/auto_ws/install/nonpersistent_voxel_layer/lib/libnonpersistent_voxel_layer_core.so: undefined symbol: _ZTIN15nav2_costmap_2d13ObstacleLayerE, at ./src/shared_library.c:99 (execute_callback() at ./src/lifecycle_node_interface_impl.cpp:511)
`

cc @doisyg
 